### PR TITLE
MNT: added argument in plt.savefig

### DIFF
--- a/continuous_integration/environment-3.6.yml
+++ b/continuous_integration/environment-3.6.yml
@@ -2,12 +2,12 @@ name: test_env
 channels:
   - conda-forge
   - defaults
- dependencies:
-   - python=3.6
-   - arm_pyart
-   - numpy
-   - pandas
-   - netcdf4
-   - xarray
-   - matplotlib
-   - pytest
+dependencies:
+  - python=3.6
+  - arm_pyart
+  - numpy
+  - pandas
+  - netcdf4
+  - xarray
+  - matplotlib
+  - pytest

--- a/vad/vad_quicklooks.py
+++ b/vad/vad_quicklooks.py
@@ -69,7 +69,7 @@ def quicklooks(file, config, image_directory=None):
     plt.xlabel('Time (UTC)')
     
     plt.savefig(image_directory + '/' + plot_values['save_name']
-                + '.' + str(date) + '.000000.png') 
+                + '.' + str(date) + '.000000.png', bbox_inches='tight') 
     
     
     


### PR DESCRIPTION
Added the bbox_inches argument when saving the image to remove extra white space.
Removed spaces in the environmeny-3.6.yml file that kept causing travis to fail